### PR TITLE
fix no file / folder hidden when obsidian open

### DIFF
--- a/src/commands/toggleVisibility.ts
+++ b/src/commands/toggleVisibility.ts
@@ -3,12 +3,13 @@ import FileHider from "../main";
 // The command used to toggle the visibility.
 export class VisibilityToggleCommand {
 	constructor(plugin: FileHider) {
-		plugin.addCommand({
-			id: 'oa-fh-toggle-visibility',
-			name: 'Toggle Visibility',
-			callback: () => {
-				plugin.toggleVisibility();
-			}
-		});
+		plugin
+			.addCommand({
+				id: 'oa-fh-toggle-visibility',
+				name: 'Toggle Visibility',
+				callback: () => {
+					plugin.toggleVisibility();
+				}
+			});
 	};
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,6 +19,7 @@ export default class FileHider extends Plugin {
 	style: CSSStyleSheet|null = null;
 
 	async onload() {
+
 		await this.loadSettings();
 		this.registerEvent(
 			this.app.workspace.on(`file-menu`, (menu, file) => {
@@ -63,7 +64,7 @@ export default class FileHider extends Plugin {
 		);
 
 
-		this.app.workspace.onLayoutReady( async () => {
+		this.app.workspace.onLayoutReady(async () => {
 			await sleep(50)
 			for (const path of this.settings.hiddenList) {
 				await changePathVisibility(path, this.settings.hidden);

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,42 +21,47 @@ export default class FileHider extends Plugin {
 	async onload() {
 
 		await this.loadSettings();
+		console.log('FileHider loaded');
 		this.registerEvent(
 			this.app.workspace.on(`file-menu`, (menu, file) => {
 				if (file instanceof TFolder) {
 					menu.addItem((i) => {
 						if (this.settings.hiddenList.includes(file.path)) {
-							i.setTitle(`Unhide Folder`)
-							.setIcon(`eye`)
-							.onClick(() => {
-								this.unhidePath(file.path);
-							});
+							i
+								.setTitle(`Unhide Folder`)
+								.setIcon(`eye`)
+								.onClick(() => {
+									this.unhidePath(file.path);
+								});
 						} else {
-							i.setTitle(`Hide Folder`)
-							.setIcon(`eye-off`)
-							.onClick(() => {
-								changePathVisibility(file.path, this.settings.hidden);
-								this.settings.hiddenList.push(file.path);
-								this.saveSettings();
-							});
+							i
+								.setTitle(`Hide Folder`)
+								.setIcon(`eye-off`)
+								.onClick(() => {
+									changePathVisibility(file.path, this.settings.hidden);
+									this.settings.hiddenList.push(file.path);
+									this.saveSettings();
+								});
 						}
 					});
 				} else {
 					menu.addItem((i) => {
 						if (this.settings.hiddenList.includes(file.path)) {
-							i.setTitle(`Unhide File`)
-							.setIcon(`eye`)
-							.onClick(() => {
-								this.unhidePath(file.path);
-							});
+							i
+								.setTitle(`Unhide File`)
+								.setIcon(`eye`)
+								.onClick(() => {
+									this.unhidePath(file.path);
+								});
 						} else {
-							i.setTitle(`Hide File`)
-							.setIcon(`eye-off`)
-							.onClick(() => {
-								changePathVisibility(file.path, this.settings.hidden);
-								this.settings.hiddenList.push(file.path);
-								this.saveSettings();
-							});
+							i
+								.setTitle(`Hide File`)
+								.setIcon(`eye-off`)
+								.onClick(() => {
+									changePathVisibility(file.path, this.settings.hidden);
+									this.settings.hiddenList.push(file.path);
+									this.saveSettings();
+								});
 						}
 					});
 				}
@@ -65,9 +70,9 @@ export default class FileHider extends Plugin {
 
 
 		this.app.workspace.onLayoutReady(async () => {
-			await sleep(50)
+			await sleep(50);
 			for (const path of this.settings.hiddenList) {
-				await changePathVisibility(path, this.settings.hidden);
+				changePathVisibility(path, this.settings.hidden);
 			}
 		});
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,7 @@ import { changePathVisibility } from './utils';
 interface FileHiderSettings {
 	hidden: boolean;
 	hiddenList: string[];
-};
+}
 
 
 export default class FileHider extends Plugin {
@@ -20,7 +20,6 @@ export default class FileHider extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
-
 		this.registerEvent(
 			this.app.workspace.on(`file-menu`, (menu, file) => {
 				if (file instanceof TFolder) {
@@ -39,34 +38,36 @@ export default class FileHider extends Plugin {
 								this.settings.hiddenList.push(file.path);
 								this.saveSettings();
 							});
-						};
+						}
 					});
 				} else {
 					menu.addItem((i) => {
 						if (this.settings.hiddenList.includes(file.path)) {
 							i.setTitle(`Unhide File`)
 							.setIcon(`eye`)
-							.onClick((e) => {
+							.onClick(() => {
 								this.unhidePath(file.path);
 							});
 						} else {
 							i.setTitle(`Hide File`)
 							.setIcon(`eye-off`)
-							.onClick((e) => {
+							.onClick(() => {
 								changePathVisibility(file.path, this.settings.hidden);
 								this.settings.hiddenList.push(file.path);
 								this.saveSettings();
 							});
-						};
+						}
 					});
-				};
+				}
 			})
 		);
 
-		this.app.workspace.onLayoutReady(() => {
+
+		this.app.workspace.onLayoutReady( async () => {
+			await sleep(50)
 			for (const path of this.settings.hiddenList) {
-				changePathVisibility(path, this.settings.hidden);
-			};
+				await changePathVisibility(path, this.settings.hidden);
+			}
 		});
 
 		new VisibilityToggleCommand(this);
@@ -88,19 +89,19 @@ export default class FileHider extends Plugin {
 	/*
 	Enables/Disables the file visibility based. (gets the stylesheet if needed)
 	*/
-	toggleVisibility() {
+	async toggleVisibility() {
 		this.settings.hidden = !this.settings.hidden;
 		for (const path of this.settings.hiddenList) {
 			changePathVisibility(path, this.settings.hidden);
-		};
-		this.saveSettings();
+		}
+		await this.saveSettings();
 	};
 
-	unhidePath(path: string) {
+	async unhidePath(path: string) {
 		let i = this.settings.hiddenList.indexOf(path);
 		this.settings.hiddenList.splice(i, 1);
 		changePathVisibility(path, false);
-		this.saveSettings();
+		await this.saveSettings();
 	};
 };
 
@@ -123,4 +124,4 @@ class FileHiderSettingsTab extends PluginSettingTab {
 		VisibilityToggleSetting.create(this.plugin, container);
 		ManageHiddenPaths.create(this.plugin, container);
 	};
-};
+}

--- a/src/modals/HiddenList.ts
+++ b/src/modals/HiddenList.ts
@@ -17,17 +17,18 @@ export class HiddenPathsModal extends Modal {
 		this.plugin.settings.hiddenList.forEach(path => {
 			let c = body.createEl(`div`);
 			new Setting(c)
-			.setName(path)
-			.addButton(btn => {
-				btn.setIcon(`cross`)
-				.setTooltip(`Remove`)
-				.onClick((e) => {
-					this.plugin.unhidePath(path);
-					c.hide();
+				.setName(path)
+				.addButton(btn => {
+					btn
+						.setIcon(`cross`)
+						.setTooltip(`Remove`)
+						.onClick(() => {
+							this.plugin.unhidePath(path);
+							c.hide();
+						});
+					});
 				});
-			});
-		});
-	}
+		}
 
 	onClose() {
 		const {contentEl} = this;

--- a/src/settings/hiddenToggle.ts
+++ b/src/settings/hiddenToggle.ts
@@ -5,14 +5,14 @@ export class VisibilityToggleSetting {
 
 	public static create(plugin: FileHider, container: HTMLElement) {
 		return new Setting(container)
-		.setName(`Hidden File Visibility`)
-		.setDesc(`Toggle whether or not files and folders that are told to be hidden will be hidden or not.`)
-		.addToggle(toggle => {
-			toggle
-			.setValue(!plugin.settings.hidden)
-			.onChange(() => {
-				plugin.toggleVisibility();
+			.setName(`Hidden File Visibility`)
+			.setDesc(`Toggle whether or not files and folders that are told to be hidden will be hidden or not.`)
+			.addToggle(toggle => {
+				toggle
+					.setValue(!plugin.settings.hidden)
+					.onChange(() => {
+						plugin.toggleVisibility();
+				});
 			});
-		});
 	};
-};
+}

--- a/src/settings/manageHiddenPaths.ts
+++ b/src/settings/manageHiddenPaths.ts
@@ -7,16 +7,16 @@ export class ManageHiddenPaths {
 
 	public static create(plugin: FileHider, container: HTMLElement) {
 		return new Setting(container)
-		.setName(`Hidden Files and Folders`)
-		.setDesc(`Add or remove files and folders from the list that are being hidden`)
-		.addButton(b => {
-			b.setButtonText(`Manage`)
-			.onClick(event => {
-				// sanity check to prevent other code from opening the modal
-				if (!event.isTrusted) { return }
-
-				new HiddenPathsModal(plugin).open()
-			});
-		});
-	};
-};
+			.setName(`Hidden Files and Folders`)
+			.setDesc(`Add or remove files and folders from the list that are being hidden`)
+			.addButton(b => {
+				b
+					.setButtonText(`Manage`)
+					.onClick(event => {
+					// sanity check to prevent other code from opening the modal
+						if (!event.isTrusted) { return }
+						new HiddenPathsModal(plugin).open();
+					});
+				});
+			};
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,9 +3,9 @@ export function changePathVisibility(path: string, hide: boolean) {
 	if (!n) {
 		return;
 	}
-	let p = n.parentElement
+	let p = n.parentElement;
 	if (hide) {
-		p.style.display = `none`
+		p.style.display = `none`;
 	} else {
 		p.style.display = ``;
 	}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,12 +1,12 @@
-export function changePathVisibility(path: string, hide: boolean) {
+export async function changePathVisibility(path: string, hide: boolean) {
 	let n = document.querySelector(`[data-path="${path}"]`);
 	if (!n) {
 		return;
-	};
+	}
 	let p = n.parentElement
 	if (hide) {
 		p.style.display = `none`
 	} else {
 		p.style.display = ``;
-	};
-};
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-export async function changePathVisibility(path: string, hide: boolean) {
+export function changePathVisibility(path: string, hide: boolean) {
 	let n = document.querySelector(`[data-path="${path}"]`);
 	if (!n) {
 		return;


### PR DESCRIPTION
See #12 

I added a little sleep `onLayoutReady` because, when Obsidian open, it return `null` with `querySelector`. 
Waiting a little the DOM loading resolve this. I use a 50 ms, but 0 or 1 ms work too. As I was afraid of breaking Obsidian, I prefer to use 50 ms. 

I also removed the unnecessary semicolon.