### PR TITLE
Fixed files not hiding on obsidian initial load

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -63,10 +63,14 @@ export default class FileHider extends Plugin {
 			})
 		);
 
-		this.app.workspace.onLayoutReady(() => {
-			for (const path of this.settings.hiddenList) {
-				changePathVisibility(path, this.settings.hidden);
-			};
+		this.app.workspace.onLayoutReady(() => 
+		{
+			// Timeout is used to delay until the file explorer is loaded. Delay of 0 works, but I set it to 200 just to be safe.
+			setTimeout(() => {
+				for (const path of this.settings.hiddenList) {
+					changePathVisibility(path, this.settings.hidden);
+				};
+			}, 200);
 		});
 
 		new VisibilityToggleCommand(this);


### PR DESCRIPTION
@Oliver-Akins Hey, I fixed the issue presented in #21. This uses `setTimeout()` to delay the hiding until the file explorer is loaded. A delay of 0 milliseconds works to fix it, I guess because since it is asyncronous on one thread, so it goes and finihes loading everything else before coming back to hide eveything. However, just to be safe I set the delay to 200ms just in case it is different on other systems.

I made sure to follow the style guidlines, however let me know if there needs to be changes.

Thanks for the plugin, it is really great!