### PR TITLE
Issue-25 Handle Carriage Returns in Filenames.

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 export function changePathVisibility(path: string, hide: boolean) {
-	let n = document.querySelector(`[data-path="${path}"]`);
+	let escapedPath = CSS.escape(path);
+	let n = document.querySelector(`[data-path="${escapedPath}"]`);
 	if (!n) {
 		return;
 	};


### PR DESCRIPTION
Added `CSS.escape(...)` to `changePathVisibility(...)` to handle carriage return (\r) and other invalid querySelector paths characters.

Supporting Documentation:
[Use CSS.escape() to escape QuerySelectorAll() - Rick Strahl's Web Log](https://weblog.west-wind.com/posts/2022/Apr/10/Use-CSSescape-to-escape-QuerySelectorAll)
[javascript - What chars needs escaping in querySelector? - Stack Overflow](https://stackoverflow.com/questions/22830519/what-chars-needs-escaping-in-queryselector)

Found root cause using the Obsidian Developer Mode. Error Message:

```
Uncaught DOMException: Failed to execute 'querySelector' on 'Document': '[data-path="Icon
"]' is not a valid selector.
    at eval (plugin:obsidian-icon-folder:3775:39)
```

Tested by closing Obsidian. Updating code in plugin folder. Open Obsidian.
Tested On macOS 12.6.3